### PR TITLE
Fix mouse pointer update parsing

### DIFF
--- a/VNC Server/Server.cs
+++ b/VNC Server/Server.cs
@@ -228,8 +228,8 @@ namespace VNC_Server
 
             // Разбор сообщения
             string[] parts = message.Split(',');
-            int mouseX = Convert.ToInt32($"{parts[0]}");
-            int mouseY = Convert.ToInt32($"{parts[2]}");
+            int mouseX = Convert.ToInt32(parts[0]);
+            int mouseY = Convert.ToInt32(parts[1]);
 
             MouseOperator.SetCursorPos(mouseX, mouseY);
         }


### PR DESCRIPTION
## Summary
- fix `MouseEventMoveUpdateRequest` to parse both coordinates correctly

## Testing
- `dotnet build 'Lab.5 VNC.sln'` *(fails: command not found)*
- `msbuild 'Lab.5 VNC.sln'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413412f3148328a1fd1c3dc597a790